### PR TITLE
Align secret token/passphrase naming with occson

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Or install it yourself as:
     Options:
         -a CCS_ACCESS_TOKEN,             CCS Access Token
             --access-token
-        -s CCS_SECRET_TOKEN,             CCS Secret Token
-            --secret-token
+        -p CCS_PASSPHRASE,               CCS Passphrase
+            --passphrase
 
 
 ## Example
@@ -58,10 +58,10 @@ Upload
 
     destination = 'ccs://workspace-name/0.1.0/path/to/file.yml'
     access_token = ENV.fetch('CCS_ACCESS_TOKEN')
-    secret_token = 'MySecretToken'
+    passphrase = 'MyPassphrase'
     content = 'RAILS_ENV=production'
 
-    Ccs::Document.new(destination, access_token, secret_token).upload(content)
+    Ccs::Document.new(destination, access_token, passphrase).upload(content)
 
 Download
 
@@ -69,9 +69,9 @@ Download
 
     source = 'ccs://workspace-name/0.1.0/path/to/file.yml'
     access_token = ENV.fetch('CCS_ACCESS_TOKEN')
-    secret_token = 'MySecretToken'
+    passphrase = 'MyPassphrase'
 
-    Ccs::Document.new(source, access_token, secret_token).download
+    Ccs::Document.new(source, access_token, passphrase).download
 
 ## Development
 

--- a/exe/ccs
+++ b/exe/ccs
@@ -9,7 +9,7 @@ require 'io/console'
 
 options = {
   'access_token' => ENV['CCS_ACCESS_TOKEN'],
-  'secret_token' => ENV['CCS_SECRET_TOKEN']
+  'passphrase' => ENV['CCS_PASSPHRASE']
 }
 
 option_parser = OptionParser.new do |option_parser|
@@ -38,14 +38,14 @@ when 'cp'
       options['access_token'] = v
     end
 
-    option_parser.on('-s CCS_SECRET_TOKEN', '--secret-token CCS_SECRET_TOKEN', String, 'CCS Secret Token') do |v|
-      options['secret_token'] = v
+    option_parser.on('-p CCS_PASSPHRASE', '--passphrase CCS_PASSPHRASE', String, 'CCS Passphrase') do |v|
+      options['passphrase'] = v
     end
 
     option_parser.separator ''
     option_parser.separator 'Configure via environment variables:'
     option_parser.separator '  CCS_ACCESS_TOKEN'
-    option_parser.separator '  CCS_SECRET_TOKEN'
+    option_parser.separator '  CCS_PASSPHRASE'
 
     option_parser.separator ''
     option_parser.separator 'Examples:'
@@ -73,11 +73,11 @@ when 'cp'
   end
 
   raise OptionParser::MissingArgument, 'access_token' unless options['access_token']
-  raise OptionParser::MissingArgument, 'secret_token' unless options['secret_token']
+  raise OptionParser::MissingArgument, 'passphrase' unless options['passphrase']
   raise OptionParser::MissingArgument, 'source' unless arguments.fetch(0, nil)
   raise OptionParser::MissingArgument, 'destination' unless arguments.fetch(1, nil)
 
-  exit(1) unless Ccs::Commands::Copy.new(arguments[0], arguments[1], options['access_token'], options['secret_token']).call
+  exit(1) unless Ccs::Commands::Copy.new(arguments[0], arguments[1], options['access_token'], options['passphrase']).call
 else
   puts option_parser
   exit(1)

--- a/lib/ccs/commands/copy.rb
+++ b/lib/ccs/commands/copy.rb
@@ -3,11 +3,11 @@
 module Ccs
   module Commands
     class Copy
-      def initialize(source, destination, access_token, secret_token)
+      def initialize(source, destination, access_token, passphrase)
         @source = source
         @destination = destination
         @access_token = access_token
-        @secret_token = secret_token
+        @passphrase = passphrase
       end
 
       def call
@@ -21,7 +21,7 @@ module Ccs
       end
 
       def download
-        content = Document.new(@source, @access_token, @secret_token).download
+        content = Document.new(@source, @access_token, @passphrase).download
         return unless content
 
         (@destination.eql?('-') ? STDOUT : File.new(@destination, 'w')).print content
@@ -29,7 +29,7 @@ module Ccs
 
       def upload
         content = @source.eql?('-') ? STDIN.read : File.read(@source)
-        Document.new(@destination, @access_token, @secret_token).upload(content)
+        Document.new(@destination, @access_token, @passphrase).upload(content)
       end
     end
   end

--- a/lib/ccs/document.rb
+++ b/lib/ccs/document.rb
@@ -2,18 +2,18 @@
 
 module Ccs
   class Document
-    def initialize(uri, access_token, secret_token)
+    def initialize(uri, access_token, passphrase)
       @uri = build_uri(uri)
       @access_token = access_token
-      @secret_token = secret_token
+      @passphrase = passphrase
     end
 
     def upload(content)
-      Uploader.new(@uri, content, @access_token, @secret_token).call
+      Uploader.new(@uri, content, @access_token, @passphrase).call
     end
 
     def download
-      Downloader.new(@uri, @access_token, @secret_token).call
+      Downloader.new(@uri, @access_token, @passphrase).call
     end
 
     private

--- a/lib/ccs/downloader.rb
+++ b/lib/ccs/downloader.rb
@@ -2,10 +2,10 @@
 
 module Ccs
   class Downloader
-    def initialize(uri, access_token, secret_token)
+    def initialize(uri, access_token, passphrase)
       @uri = uri
       @access_token = access_token
-      @secret_token = secret_token
+      @passphrase = passphrase
     end
 
     def call
@@ -14,7 +14,7 @@ module Ccs
       return unless response.code.eql? '200'
       json = JSON.parse body
 
-      Decrypter.new(@secret_token, json['encrypted_content']).call
+      Decrypter.new(@passphrase, json['encrypted_content']).call
     end
 
     private

--- a/lib/ccs/uploader.rb
+++ b/lib/ccs/uploader.rb
@@ -2,11 +2,11 @@
 
 module Ccs
   class Uploader
-    def initialize(uri, content, access_token, secret_token)
+    def initialize(uri, content, access_token, passphrase)
       @uri = uri
       @content = content
       @access_token = access_token
-      @secret_token = secret_token
+      @passphrase = passphrase
     end
 
     def call
@@ -36,7 +36,7 @@ module Ccs
     end
 
     def encrypted_content
-      @encrypted_content ||= Encrypter.new(@secret_token, @content, salt).call
+      @encrypted_content ||= Encrypter.new(@passphrase, @content, salt).call
     end
 
     def salt

--- a/spec/integration/ccs/commands/copy_spec.rb
+++ b/spec/integration/ccs/commands/copy_spec.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe Ccs::Commands::Copy do
-  let(:application) { described_class.new source, destination, access_token, secret_token }
+  let(:application) { described_class.new source, destination, access_token, passphrase }
 
   subject { application }
 
   let(:access_token) { 'access_token' }
-  let(:secret_token) { 'secret_token' }
+  let(:passphrase) { 'passphrase' }
 
   before do
     stub_request(:get, 'http://example.com/a/b/c.txt')
       .to_return(status: 200,
                  body: { message: 'OK', status: '200',
-                         encrypted_content: 'U2FsdGVkX19zZWNyZXRfdAysfeMlKF4wGAULx3axRnM=' }.to_json,
+                         encrypted_content: 'U2FsdGVkX19zZWNyZXRfdDngaQw8zQbHado/FhnBIsQ=' }.to_json,
                  headers: { 'Content-Type' => 'application/json' })
     stub_request(:post, 'http://example.com/a/b/c.txt')
       .to_return(status: 201,

--- a/spec/integration/ccs/document_spec.rb
+++ b/spec/integration/ccs/document_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe Ccs::Document do
-  let(:document) { described_class.new uri, access_token, secret_token }
+  let(:document) { described_class.new uri, access_token, passphrase }
 
   subject { document }
 
   let(:access_token) { 'access_token' }
-  let(:secret_token) { 'secret_token' }
+  let(:passphrase) { 'passphrase' }
   let(:uri) { 'ccs://a/b/c.txt' }
 
   before do
     stub_request(:get, 'https://api.occson.com/a/b/c.txt')
       .to_return(status: 200,
                  body: { message: 'OK', status: '200',
-                         encrypted_content: 'U2FsdGVkX19zZWNyZXRfdAysfeMlKF4wGAULx3axRnM=' }.to_json,
+                         encrypted_content: 'U2FsdGVkX19zZWNyZXRfdDngaQw8zQbHado/FhnBIsQ=' }.to_json,
                  headers: { 'Content-Type' => 'application/json' })
     stub_request(:post, 'https://api.occson.com/a/b/c.txt')
       .to_return(status: 201,

--- a/spec/integration/ccs/downloader_spec.rb
+++ b/spec/integration/ccs/downloader_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Ccs::Downloader do
-  let(:downloader) { described_class.new uri, access_token, secret_token }
+  let(:downloader) { described_class.new uri, access_token, passphrase }
 
   subject { downloader }
 
@@ -10,7 +10,7 @@ RSpec.describe Ccs::Downloader do
       .to_return(status: 200,
                  body: { message: 'OK',
                          status: '200',
-                         encrypted_content: 'U2FsdGVkX19zZWNyZXRfdAysfeMlKF4wGAULx3axRnM=' }.to_json,
+                         encrypted_content: 'U2FsdGVkX19zZWNyZXRfdDngaQw8zQbHado/FhnBIsQ=' }.to_json,
                  headers: { 'Content-Type' => 'application/json' })
     stub_request(:get, 'http://example.com/a/b/c.yml')
       .with(headers: { 'Authorization' => 'Token token=open_token' })
@@ -26,7 +26,7 @@ RSpec.describe Ccs::Downloader do
   describe '#call' do
     let(:uri) { URI 'http://example.com/a/b/c.yml' }
     let(:access_token) { 'access_token' }
-    let(:secret_token) { 'secret_token' }
+    let(:passphrase) { 'passphrase' }
 
     it { expect(subject.call).to eq 'content' }
 

--- a/spec/integration/ccs/uploader_spec.rb
+++ b/spec/integration/ccs/uploader_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Ccs::Uploader do
-  let(:uploader) { described_class.new uri, content, access_token, secret_token }
+  let(:uploader) { described_class.new uri, content, access_token, passphrase }
 
   subject { uploader }
 
@@ -25,7 +25,7 @@ RSpec.describe Ccs::Uploader do
     let(:uri) { URI 'http://example.com/a/b/c.yml' }
     let(:content) { 'content' }
     let(:access_token) { 'access_token' }
-    let(:secret_token) { 'secret_token' }
+    let(:passphrase) { 'passphrase' }
 
     it { expect(subject.call).to eq true }
 

--- a/spec/unit/ccs/decrypter_spec.rb
+++ b/spec/unit/ccs/decrypter_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Ccs::Decrypter do
   subject { decrypter }
 
   describe '#call' do
-    let(:passphrase) { 'secret_token' }
-    let(:content) { 'U2FsdGVkX19zZWNyZXRfdAysfeMlKF4wGAULx3axRnM=' }
+    let(:passphrase) { 'passphrase' }
+    let(:content) { 'U2FsdGVkX19zZWNyZXRfdDngaQw8zQbHado/FhnBIsQ='}
 
     it { expect(subject.call).to eq 'content' }
   end

--- a/spec/unit/ccs/encrypter_spec.rb
+++ b/spec/unit/ccs/encrypter_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Ccs::Encrypter do
   subject { encrypter }
 
   describe '#call' do
-    let(:passphrase) { 'secret_token' }
+    let(:passphrase) { 'passphrase' }
     let(:content) { 'content' }
     let(:salt) { 'secret_t' }
 
-    it { expect(subject.call).to eq 'U2FsdGVkX19zZWNyZXRfdAysfeMlKF4wGAULx3axRnM=' }
+    it { expect(subject.call).to eq 'U2FsdGVkX19zZWNyZXRfdDngaQw8zQbHado/FhnBIsQ=' }
   end
 end


### PR DESCRIPTION
This is intended to align the inconsistency between "secret token" meaning the same in CCS as "passphrase" means in occson, and avoid any confusion/documentation clarity issues.